### PR TITLE
Make native members of Window and Application public

### DIFF
--- a/webview.hpp
+++ b/webview.hpp
@@ -73,14 +73,11 @@ class Application {
 
     id appDelegate;
 
-    /// Adds the default menubar menus on macOS
-//    void addDefaultMenus();
-
 #endif
-
-    ApplicationType app;
-    MenuBarType menubar;
 public:
+    ApplicationType nativeApp;
+    MenuBarType nativeMenubar;
+
     /// Creates a new Application
     Application();
 
@@ -110,7 +107,6 @@ public:
 class Window {
     friend class Application;
 
-    WindowType window;
     WebViewType webView;
 
     std::string loadedHTML;
@@ -132,6 +128,8 @@ class Window {
     Window(const char *title, int width, int height, WindowStyle style = WindowStyle::Default);
 
 public:
+    WindowType nativeWindow;
+
     WindowCloseHandler closeHandler;
 
     /// Sets the title of the window

--- a/webview_cocoa.cpp
+++ b/webview_cocoa.cpp
@@ -60,19 +60,19 @@ void addUserScript(id webView, const char *javaScript) {
 
 Window::Window(const char *title, int width, int height, WindowStyle style) {
     // Create NSWindow
-    window = objc_msgSend("NSWindow"_cls, "alloc"_sel);
-    objc_msgSend(window, "initWithContentRect:styleMask:backing:defer:"_sel, CGRectMake(0, 0, width, height),
+    nativeWindow = objc_msgSend("NSWindow"_cls, "alloc"_sel);
+    objc_msgSend(nativeWindow, "initWithContentRect:styleMask:backing:defer:"_sel, CGRectMake(0, 0, width, height),
                  style, 2, 0);
-    objc_msgSend(window, "autorelease"_sel);
+    objc_msgSend(nativeWindow, "autorelease"_sel);
 
-    objc_setAssociatedObject(window, "window", reinterpret_cast<id>(this), OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(nativeWindow, "window", reinterpret_cast<id>(this), OBJC_ASSOCIATION_ASSIGN);
 
-    objc_msgSend(window, "setDelegate:"_sel, windowDelegate);
+    objc_msgSend(nativeWindow, "setDelegate:"_sel, windowDelegate);
 
     // Set Window title
-    objc_msgSend(window, "setTitle:"_sel, asNSString(title));
+    objc_msgSend(nativeWindow, "setTitle:"_sel, asNSString(title));
 
-    objc_msgSend(window, "cascadeTopLeftFromPoint:"_sel, CGPointMake(1, 0));
+    objc_msgSend(nativeWindow, "cascadeTopLeftFromPoint:"_sel, CGPointMake(1, 0));
 
     // Create WKWebViewConfiguration
     id configuration = objc_msgSend("WKWebViewConfiguration"_cls, "alloc"_sel);
@@ -92,16 +92,16 @@ Window::Window(const char *title, int width, int height, WindowStyle style) {
     objc_msgSend(webView, "setTranslatesAutoresizingMaskIntoConstraints:"_sel, 0);
 
     // Add web view to window
-    objc_msgSend(objc_msgSend(window, "contentView"_sel), "addSubview:"_sel, webView);
+    objc_msgSend(objc_msgSend(nativeWindow, "contentView"_sel), "addSubview:"_sel, webView);
 
     // Set width anchor of web view to be equal to window
     objc_msgSend(objc_msgSend(objc_msgSend(webView, "widthAnchor"_sel), "constraintEqualToAnchor:"_sel,
-                              objc_msgSend(objc_msgSend(window, "contentView"_sel), "widthAnchor"_sel)),
+                              objc_msgSend(objc_msgSend(nativeWindow, "contentView"_sel), "widthAnchor"_sel)),
                  "setActive:"_sel, 1);
 
     // Set height anchor of web view to be equal to window
     objc_msgSend(objc_msgSend(objc_msgSend(webView, "heightAnchor"_sel), "constraintEqualToAnchor:"_sel,
-                              objc_msgSend(objc_msgSend(window, "contentView"_sel), "heightAnchor"_sel)),
+                              objc_msgSend(objc_msgSend(nativeWindow, "contentView"_sel), "heightAnchor"_sel)),
                  "setActive:"_sel, 1);
 
     handlerInstance = objc_msgSend((id) handlerClass, "alloc"_sel);
@@ -112,18 +112,18 @@ Window::Window(const char *title, int width, int height, WindowStyle style) {
 }
 
 void Window::orderFront() {
-    objc_msgSend(window, "makeKeyAndOrderFront:"_sel, nullptr);
+    objc_msgSend(nativeWindow, "makeKeyAndOrderFront:"_sel, nullptr);
 }
 
 void Window::setTitle(const char *title) {
-    objc_msgSend(window, "setTitle:"_sel, asNSString(title));
+    objc_msgSend(nativeWindow, "setTitle:"_sel, asNSString(title));
 }
 
 void Window::setSize(int width, int height) {
-    auto frame = (CGRect *) objc_msgSend(window, "valueForKey:"_sel, "frame"_str);
+    auto frame = (CGRect *) objc_msgSend(nativeWindow, "valueForKey:"_sel, "frame"_str);
     frame->size.width = width;
     frame->size.height = height;
-    objc_msgSend(window, "setFrame:display:"_sel, *frame, true);
+    objc_msgSend(nativeWindow, "setFrame:display:"_sel, *frame, true);
 }
 
 void Window::setDeveloperToolsEnabled(bool enabled) {
@@ -174,22 +174,22 @@ void Window::setCloseHandler(const WindowCloseHandler &handler) {
 }
 
 void Window::hide() {
-    objc_msgSend(window, "orderOut:"_sel, nullptr);
+    objc_msgSend(nativeWindow, "orderOut:"_sel, nullptr);
 }
 
 void Window::show() {
-    if (objc_msgSend(window, "isMiniaturized"_sel)) {
-        objc_msgSend(window, "deminiaturize:"_sel, nullptr);
+    if (objc_msgSend(nativeWindow, "isMiniaturized"_sel)) {
+        objc_msgSend(nativeWindow, "deminiaturize:"_sel, nullptr);
     }
     orderFront();
 }
 
 void Window::minimize() {
-    objc_msgSend(window, "miniaturize:"_sel, nullptr);
+    objc_msgSend(nativeWindow, "miniaturize:"_sel, nullptr);
 }
 
 void Window::close() {
-    objc_msgSend(window, "performClose:"_sel, nullptr);
+    objc_msgSend(nativeWindow, "performClose:"_sel, nullptr);
 }
 
 JSType getJSType(const std::string &name) {
@@ -280,14 +280,14 @@ void addDefaultMenus(id menubar) {
 Application::Application() {
     // Create Autorelease pool
     objc_msgSend("NSAutoreleasePool"_cls, "new"_sel);
-    app = objc_msgSend("NSApplication"_cls, "sharedApplication"_sel);
+    nativeApp = objc_msgSend("NSApplication"_cls, "sharedApplication"_sel);
 
     // Create Menu
-    menubar = objc_msgSend("NSMenu"_cls, "new"_sel);
-    objc_msgSend(menubar, "autorelease"_sel);
-    objc_msgSend(app, "setMainMenu:"_sel, menubar);
+    nativeMenubar = objc_msgSend("NSMenu"_cls, "new"_sel);
+    objc_msgSend(nativeMenubar, "autorelease"_sel);
+    objc_msgSend(nativeApp, "setMainMenu:"_sel, nativeMenubar);
 
-    addDefaultMenus(menubar);
+    addDefaultMenus(nativeMenubar);
 
     // Create AppDelegate
     Class appDelegateClass = objc_allocateClassPair((Class) "NSObject"_cls, "AppDelegate", 0);
@@ -324,7 +324,7 @@ Application::Application() {
     appDelegate = objc_msgSend("AppDelegate"_cls, "new"_sel);
     objc_msgSend(appDelegate, "autorelease"_sel);
 
-    objc_msgSend(app, "setDelegate:"_sel, appDelegate);
+    objc_msgSend(nativeApp, "setDelegate:"_sel, appDelegate);
 
     Class windowDelegateClass = objc_allocateClassPair((Class) "NSObject"_cls, "WindowDelegate", 0);
 
@@ -401,7 +401,7 @@ Application::Application() {
 Application::~Application() = default;
 
 void Application::addMenu(Menu &menu) {
-    id menuItem = createMenu(menubar, asNSString(menu.name.c_str()));
+    id menuItem = createMenu(nativeMenubar, asNSString(menu.name.c_str()));
     for (const auto &item : menu.items) {
         menuBarHandlers[item.name] = item.handler;
         class_addMethod(object_getClass(appDelegate), sel_registerName(item.name.c_str()), (IMP) +[](id self, SEL cmd) {
@@ -413,11 +413,11 @@ void Application::addMenu(Menu &menu) {
 }
 
 void Application::run() {
-    objc_msgSend(app, "run"_sel);
+    objc_msgSend(nativeApp, "run"_sel);
 }
 
 // Note: this won't call window close handlers. A workaround is possible but I think a future notice in the
 // documentation is good enough for now.
 void Application::quit() {
-    objc_msgSend(app, "terminate:"_sel, nullptr);
+    objc_msgSend(nativeApp, "terminate:"_sel, nullptr);
 }

--- a/webview_gtk.cpp
+++ b/webview_gtk.cpp
@@ -8,8 +8,8 @@
 #include <utility>
 #include "webview.hpp"
 
-GtkApplication *Application::app = nullptr;
-GMenu *Application::menubar = nullptr;
+GtkApplication *Application::nativeApp = nullptr;
+GMenu *Application::nativeMenubar = nullptr;
 
 struct JSHandlerInfo {
     const char *name;
@@ -21,22 +21,22 @@ std::map<std::string, JSHandlerInfo> handlers;
 
 Application::Application() {
     gtk_init_check(nullptr, nullptr);
-    if (!app) app = gtk_application_new(nullptr, G_APPLICATION_FLAGS_NONE);
+    if (!nativeApp) nativeApp = gtk_application_new(nullptr, G_APPLICATION_FLAGS_NONE);
     GActionEntry actions[] = {"quit",
                               +[](GSimpleAction *, GVariant *, void *app) { g_application_quit(G_APPLICATION(app)); },
                               nullptr, nullptr,
                               nullptr};
-    g_action_map_add_action_entries(G_ACTION_MAP(app), actions, 1, app);
+    g_action_map_add_action_entries(G_ACTION_MAP(nativeApp), actions, 1, nativeApp);
 
-    g_application_register(G_APPLICATION(app), nullptr, nullptr);
+    g_application_register(G_APPLICATION(nativeApp), nullptr, nullptr);
 
-    if (!menubar) menubar = g_menu_new();
-    gtk_application_set_menubar(app, G_MENU_MODEL(menubar));
+    if (!nativeMenubar) nativeMenubar = g_menu_new();
+    gtk_application_set_menubar(nativeApp, G_MENU_MODEL(nativeMenubar));
 }
 
 Application::~Application() {
-    g_object_unref(app);
-    g_object_unref(menubar);
+    g_object_unref(nativeApp);
+    g_object_unref(nativeMenubar);
 }
 
 void Application::addMenu(Menu &menu) {
@@ -49,44 +49,45 @@ void Application::addMenu(Menu &menu) {
         g_signal_connect(action, "activate", G_CALLBACK(+[](GSimpleAction *, GVariant *, void *handler) {
             (*reinterpret_cast<MenuBarHandler *>(handler))();
         }), reinterpret_cast<gpointer>(&item.handler));
-        g_action_map_add_action(G_ACTION_MAP(app), G_ACTION(action));
+        g_action_map_add_action(G_ACTION_MAP(nativeApp), G_ACTION(action));
         g_menu_append(section, item.name.c_str(),
                       g_action_print_detailed_name((std::string("app.") + action_name).c_str(), nullptr));
     }
     g_menu_append_submenu(m, menu.name.c_str(), G_MENU_MODEL(section));
-    g_menu_append_section(menubar, nullptr, G_MENU_MODEL(m));
+    g_menu_append_section(nativeMenubar, nullptr, G_MENU_MODEL(m));
     g_object_unref(m);
     g_object_unref(section);
 }
 
 void Application::run() {
-    g_application_run(G_APPLICATION(app), 0, nullptr);
+    g_application_run(G_APPLICATION(nativeApp), 0, nullptr);
 }
 
 void Application::quit() {
-    g_application_quit(G_APPLICATION(app));
+    g_application_quit(G_APPLICATION(nativeApp));
 }
 
 Window::Window(const char *title, int width, int height, WindowStyle style) {
-    window = gtk_application_window_new(GTK_APPLICATION(g_application_get_default()));
+    nativeWindow = gtk_application_window_new(GTK_APPLICATION(g_application_get_default()));
 
-    gtk_window_set_title(GTK_WINDOW(window), title);
-    gtk_window_set_default_size(GTK_WINDOW(window), width, height);
-    gtk_window_set_resizable(GTK_WINDOW(window), (unsigned int) style & (unsigned int) WindowStyle::Resizable);
-    gtk_window_set_decorated(GTK_WINDOW(window), !((unsigned int) style & (unsigned int) WindowStyle::Borderless));
-    gtk_window_set_deletable(GTK_WINDOW(window), (unsigned int) style & (unsigned int) WindowStyle::Closable);
+    gtk_window_set_title(GTK_WINDOW(nativeWindow), title);
+    gtk_window_set_default_size(GTK_WINDOW(nativeWindow), width, height);
+    gtk_window_set_resizable(GTK_WINDOW(nativeWindow), (unsigned int) style & (unsigned int) WindowStyle::Resizable);
+    gtk_window_set_decorated(GTK_WINDOW(nativeWindow),
+                             !((unsigned int) style & (unsigned int) WindowStyle::Borderless));
+    gtk_window_set_deletable(GTK_WINDOW(nativeWindow), (unsigned int) style & (unsigned int) WindowStyle::Closable);
 
     webView = WEBKIT_WEB_VIEW(webkit_web_view_new());
 
-    gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(webView));
+    gtk_container_add(GTK_CONTAINER(nativeWindow), GTK_WIDGET(webView));
 
-    gtk_application_window_set_show_menubar(GTK_APPLICATION_WINDOW(window), true);
+    gtk_application_window_set_show_menubar(GTK_APPLICATION_WINDOW(nativeWindow), true);
 
     g_signal_connect(g_application_get_default(), "activate",
                      (GCallback) + [](GtkApplication *app, gpointer user_data) {
                          gtk_application_add_window(app, (GtkWindow *) user_data);
-                     }, window);
-    g_signal_connect(G_OBJECT(window), "delete-event",
+                     }, nativeWindow);
+    g_signal_connect(G_OBJECT(nativeWindow), "delete-event",
                      (GCallback) + [](GtkWidget *widget, GdkEvent *, gpointer user_data) {
                          auto window = reinterpret_cast<Window *>(user_data);
                          return window->closeHandler ? !window->closeHandler(window) : false;
@@ -95,15 +96,15 @@ Window::Window(const char *title, int width, int height, WindowStyle style) {
 }
 
 void Window::orderFront() {
-    gtk_widget_grab_focus(window);
+    gtk_widget_grab_focus(nativeWindow);
 }
 
 void Window::setTitle(const char *title) {
-    gtk_window_set_title(GTK_WINDOW(window), title);
+    gtk_window_set_title(GTK_WINDOW(nativeWindow), title);
 }
 
 void Window::setSize(int width, int height) {
-    gtk_window_set_default_size(GTK_WINDOW(window), width, height);
+    gtk_window_set_default_size(GTK_WINDOW(nativeWindow), width, height);
 }
 
 void Window::loadHTMLString(const char *html) {
@@ -154,12 +155,12 @@ void Window::addHandler(const char *name, HandlerFunc handler) {
 }
 
 void Window::hide() {
-    gtk_widget_hide(window);
+    gtk_widget_hide(nativeWindow);
 }
 
 void Window::show() {
-    gtk_window_deiconify(GTK_WINDOW(window));
-    gtk_widget_show_all(window);
+    gtk_window_deiconify(GTK_WINDOW(nativeWindow));
+    gtk_widget_show_all(nativeWindow);
 }
 
 void Window::setCloseHandler(const WindowCloseHandler &handler) {
@@ -167,9 +168,9 @@ void Window::setCloseHandler(const WindowCloseHandler &handler) {
 }
 
 void Window::minimize() {
-    gtk_window_iconify(GTK_WINDOW(window));
+    gtk_window_iconify(GTK_WINDOW(nativeWindow));
 }
 
 void Window::close() {
-    gtk_window_close(GTK_WINDOW(window));
+    gtk_window_close(GTK_WINDOW(nativeWindow));
 }


### PR DESCRIPTION
I made native variables of Window and Application public to allow other people to extend their functionality. The names were prefixed with "native" to show their purpose.